### PR TITLE
Substitute md5 for sha1sum

### DIFF
--- a/bfinject
+++ b/bfinject
@@ -160,8 +160,8 @@ for DYLIB in ${DYLIBS[@]}; do
     fi
     
     # Use random filenames to avoid cached binaries causing "Killed: 9" messages.
-    RAND=`dd if=/dev/random bs=1 count=16 2>/dev/null | md5`
-    RANDOM_NAME="${INJECTOR%/*}/`dd if=/dev/random bs=1 count=16 2>/dev/null | md5`"
+    RAND=`dd if=/dev/random bs=1 count=16 2>/dev/null | sha1sum`
+    RANDOM_NAME="${INJECTOR%/*}/`dd if=/dev/random bs=1 count=16 2>/dev/null | sha1sum`"
     DYLIB_DIR="/System/Library/Frameworks/${RAND}.framework"
     DYLIB_PATH="$DYLIB_DIR/$RAND.dylib"
 


### PR DESCRIPTION
`Electra`'s Core Utilities package doesn't include `md5` on iOS 11.3.1, but it includes `sha1sum`. This simple fix should still work on previous versions of `Electra` or `LiberiOS`.