### PR TITLE
updated for unc0ver

### DIFF
--- a/bfinject
+++ b/bfinject
@@ -144,8 +144,12 @@ elif [ -f /jb/usr/local/bin/jtool ]; then
     JTOOL=jtool
     INJECTOR=`pwd`/bfinject4realz
 else
-    echo "[!] Unknown jailbreak. Aborting."
-    exit 1
+    # hacky way of finding unc0ver
+    # just make sure JTOOL is in your path
+    echo "[*] edit line 151 with jtool path if this doesnt work"
+    echo "[*] Unc0ver __detected__: make sure JTOOL is in path"
+    JTOOL=jtool
+    INJECTOR=`pwd`/bfinject4realz
 fi
 
 


### PR DESCRIPTION
#### Card
Only a PR for visibility, it doesn't actually improve the tool.
#### Details
I know a couple people that don't think bfinject doesn't work on anything other than iOS 11-11.1.2. But, it works as long as you have jtool in your path, I've tested it on 11.4 with the above settings.

As I mentioned, no need to merge the PR as it doesn't make the tool better, just for other reverse engineers to view.