### PR TITLE
Fixed _phread_set_self call for iOS13

### DIFF
--- a/lorgnette.mm
+++ b/lorgnette.mm
@@ -177,7 +177,7 @@ int _image_headers_from_dyld_info64(task_t target,
 	int err = KERN_FAILURE;
 	struct dyld_all_image_infos_64 infos;
 	vm_size_t size = dyld_info.all_image_info_size;
-	err = vm_read_overwrite(target, dyld_info.all_image_info_addr, size,
+	err = vm_read_overwrite(target, dyld_info.all_image_info_addr, sizeof(infos),
 								 (vm_address_t)&infos, &size);
 	////RDFailOnError("vm_read_overwrite()", fail);
 


### PR DESCRIPTION
#### Card
iOS 13 compatibility

#### Details
Fixed a few bugs, and instead of calling _pthread_set_self, called an internal dyld function, because the original exported function won't get NULL as an argument now. 
Tested on iOS 13.1.3, with checkra1n jailbreak.